### PR TITLE
Adjust(Permission): Permission to use the MG configuration folder

### DIFF
--- a/app/src/main/java/com/fcl/plugin/mobileglues/MainActivity.java
+++ b/app/src/main/java/com/fcl/plugin/mobileglues/MainActivity.java
@@ -179,7 +179,6 @@ public class MainActivity extends ComponentActivity implements AdapterView.OnIte
     }
 
     private void checkPermissionSilently() {
-        System.out.println("TEST");
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             MGDirectoryUri = folderPermissionManager.getMGFolderUri();
 

--- a/app/src/main/java/com/fcl/plugin/mobileglues/MainActivity.java
+++ b/app/src/main/java/com/fcl/plugin/mobileglues/MainActivity.java
@@ -24,7 +24,6 @@ import android.provider.DocumentsContract;
 import android.provider.Settings;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
 import android.widget.AdapterView;
@@ -44,8 +43,11 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
 import com.fcl.plugin.mobileglues.settings.MGConfig;
+import com.fcl.plugin.mobileglues.settings.FolderPermissionManager;
+import com.fcl.plugin.mobileglues.utils.Constants;
 import com.fcl.plugin.mobileglues.utils.ResultListener;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.logging.Level;
@@ -56,6 +58,7 @@ public class MainActivity extends ComponentActivity implements AdapterView.OnIte
     public static Uri MGDirectoryUri;
     public static Context MainActivityContext;
     private MGConfig config = null;
+    private FolderPermissionManager folderPermissionManager;
     private Button openOptions;
 
     private LinearLayout optionLayout;
@@ -69,8 +72,10 @@ public class MainActivity extends ComponentActivity implements AdapterView.OnIte
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        folderPermissionManager = new FolderPermissionManager(this);
         MainActivityContext = this;
         openOptions = findViewById(R.id.open_options);
+        Button clearPermission = findViewById(R.id.clear_permission);
 
         inputMaxGlslCacheSize = findViewById(R.id.input_max_glsl_cache_size);
         optionLayout = findViewById(R.id.option_layout);
@@ -96,7 +101,15 @@ public class MainActivity extends ComponentActivity implements AdapterView.OnIte
         noErrorSpinner.setAdapter(noErrorAdapter);
 
         openOptions.setOnClickListener(view -> checkPermission());
+        clearPermission.setOnClickListener(view -> {
+            folderPermissionManager.clearAllPermissions();
+            checkPermissionSilently();
+        });
+    }
 
+    @Override
+    protected void onResume() {
+        super.onResume();
         checkPermissionSilently();
     }
 
@@ -160,16 +173,28 @@ public class MainActivity extends ComponentActivity implements AdapterView.OnIte
         }
     }
 
+    private void hideOptions() {
+        openOptions.setVisibility(View.VISIBLE);
+        optionLayout.setVisibility(View.GONE);
+    }
+
     private void checkPermissionSilently() {
+        System.out.println("TEST");
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            MGDirectoryUri = folderPermissionManager.getMGFolderUri();
+
             MGConfig config = MGConfig.loadConfig(this);
             if (config != null && MGDirectoryUri != null) {
                 showOptions();
+            } else {
+                hideOptions();
             }
         } else {
             if (ActivityCompat.checkSelfPermission(this, READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED
                     && ContextCompat.checkSelfPermission(this, WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
                 showOptions();
+            } else {
+                hideOptions();
             }
         }
     }
@@ -185,6 +210,22 @@ public class MainActivity extends ComponentActivity implements AdapterView.OnIte
                         ResultListener.startActivityForResult(this, intent, REQUEST_CODE_SAF, (requestCode, resultCode, data) -> {
                             if (requestCode == REQUEST_CODE_SAF && resultCode == RESULT_OK && data != null) {
                                 Uri treeUri = data.getData();
+                                if (treeUri == null) {
+                                    hideOptions();
+                                    return;
+                                }
+
+                                if (!folderPermissionManager.isUriMatchingFilePath(treeUri, new File(Constants.MG_DIRECTORY))) {
+                                    new AlertDialog.Builder(this)
+                                            .setTitle(R.string.app_name)
+                                            .setMessage(getString(R.string.warning_path_selection_error, folderPermissionManager.getFileByUri(treeUri)))
+                                            .setPositiveButton(R.string.dialog_positive, null)
+                                            .create()
+                                            .show();
+                                    hideOptions();
+                                    return;
+                                }
+
                                 getContentResolver().takePersistableUriPermission(treeUri,
                                         Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
 
@@ -201,13 +242,13 @@ public class MainActivity extends ComponentActivity implements AdapterView.OnIte
                     })
                     .create()
                     .show();
-
         } else {
             if (ActivityCompat.checkSelfPermission(this, READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED
                     && ContextCompat.checkSelfPermission(this, WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
                 showOptions();
             } else {
                 ActivityCompat.requestPermissions(this, new String[]{WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE}, 1000);
+                hideOptions();
             }
         }
     }

--- a/app/src/main/java/com/fcl/plugin/mobileglues/settings/FolderPermissionManager.java
+++ b/app/src/main/java/com/fcl/plugin/mobileglues/settings/FolderPermissionManager.java
@@ -1,0 +1,100 @@
+package com.fcl.plugin.mobileglues.settings;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.UriPermission;
+import android.net.Uri;
+import android.os.Environment;
+import android.provider.DocumentsContract;
+
+import com.fcl.plugin.mobileglues.utils.Constants;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class FolderPermissionManager {
+    private final Context context;
+
+    public FolderPermissionManager(Context context) {
+        this.context = context;
+    }
+
+    /**
+     * @return Obtain the list of Uris that have been granted the read/write permission
+     */
+    public List<Uri> getGrantedFolderUris() {
+        List<Uri> uriList = new ArrayList<>();
+        ContentResolver contentResolver = context.getContentResolver();
+
+        for (UriPermission permission : contentResolver.getPersistedUriPermissions()) {
+            if (permission.isReadPermission() && permission.isWritePermission()) {
+                uriList.add(permission.getUri());
+            }
+        }
+        return uriList;
+    }
+
+    /**
+     * Clear existing "Use this folder" authorization
+     */
+    public void clearAllPermissions() {
+        ContentResolver contentResolver = context.getContentResolver();
+        List<UriPermission> persistedUriPermissions = contentResolver.getPersistedUriPermissions();
+        for (UriPermission permission : persistedUriPermissions) {
+            contentResolver.releasePersistableUriPermission(
+                    permission.getUri(),
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            );
+        }
+    }
+
+    public File getFileByUri(Uri uri) {
+        if (!"com.android.externalstorage.documents".equals(uri.getAuthority())) {
+            return null;
+        }
+
+        String docId;
+        if (DocumentsContract.isTreeUri(uri)) {
+            docId = DocumentsContract.getTreeDocumentId(uri);
+        } else {
+            docId = DocumentsContract.getDocumentId(uri);
+        }
+
+        String[] split = docId.split(":");
+        if (split.length < 2) return null;
+
+        String type = split[0];
+        String relativePath = split[1];
+
+        File baseDir;
+        if ("primary".equalsIgnoreCase(type)) {
+            baseDir = Environment.getExternalStorageDirectory();
+        } else {
+            return null;
+        }
+
+        return new File(baseDir, relativePath);
+    }
+
+    public boolean isUriMatchingFilePath(Uri uri, File file) {
+        File expectedFile = getFileByUri(uri);
+        if (expectedFile == null) return false;
+        return Objects.equals(expectedFile.getAbsolutePath(), file.getAbsolutePath());
+    }
+
+    public Uri getMGFolderUri() {
+        List<Uri> grantedFolderUris = getGrantedFolderUris();
+        File MGFolder = new File(Constants.MG_DIRECTORY);
+
+        for (Uri uri : grantedFolderUris) {
+            if (isUriMatchingFilePath(uri, MGFolder)) {
+                return uri;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -105,7 +105,7 @@
 
     </LinearLayout>
 
-    <View
+    <Space
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1" />
@@ -203,11 +203,19 @@
 
         </LinearLayout>
 
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:text="@string/clear_permission"
+            android:id="@+id/clear_permission" />
+
     </LinearLayout>
 
     <Button
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
         android:text="@string/open_options"
         tools:visibility="gone"
         android:id="@+id/open_options" />

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -10,6 +10,8 @@
 
     <string name="open_options">修改渲染器设置</string>
 
+    <string name="clear_permission">重置使用文件夹的授权</string>
+
     <string name="option_glsl_cache">最大 GLSL 缓存大小: (MB, 输入 0 以清除并禁用 GLSL 缓存)</string>
     <string name="option_angle">启用 ANGLE 作为 OpenGL ES 驱动</string>
     <string name="option_angle_disable_if_possible">尽可能不启用</string>
@@ -41,4 +43,5 @@
     
     <string name="warning_load_failed">无法加载 MG 配置文件！</string>
     <string name="warning_save_failed">无法保存 MG 配置文件！</string>
+    <string name="warning_path_selection_error">路径错误！请选择 内部存储/MG 文件夹 (/sdcard/MG)，但您选择了：\n%s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,8 @@
 
     <string name="open_options">Modify renderer settings</string>
 
+    <string name="clear_permission">Reset folder authorization</string>
+
     <string name="option_glsl_cache">Max glsl cache size: (MB, enter 0 to clear and disable glsl cache)</string>
     <string name="option_angle">Use ANGLE as OpenGL ES driver</string>
     <string name="option_angle_disable_if_possible">Disable if possible</string>
@@ -46,4 +48,5 @@
 
     <string name="warning_load_failed">Failed to load MG config!</string>
     <string name="warning_save_failed">Failed to save MG config!</string>
+    <string name="warning_path_selection_error">Path error! Please select the Internal Storage/MG folder (/sdcard/MG), but you selected:\n%s</string>
 </resources>


### PR DESCRIPTION
- No longer requires reconfiguring folder permissions on each app restart
- Prevent crashes caused by permission changes during app runtime
- Allow resetting currently granted folder permissions within the app
- When granting folder access, the folder will be checked for compliance.

**Needs more testing!**